### PR TITLE
Update Module Reference in Adminhtml.xml

### DIFF
--- a/app/code/community/SomethingDigital/ApplyCoupon/etc/adminhtml.xml
+++ b/app/code/community/SomethingDigital/ApplyCoupon/etc/adminhtml.xml
@@ -11,7 +11,7 @@
             <children>
               <config>
                 <children>
-                  <somethingdigital_applycoupon translate="title" module="fraudalert">
+                  <somethingdigital_applycoupon translate="title" module="applycoupon">
                     <title>Auto Apply Coupon Code Settings.</title>
                   </somethingdigital_applycoupon>
                 </children>


### PR DESCRIPTION
  - Update reference to helper to fix role permission issue on Papyrus
>[Wed Dec 28 18:08:28 2016] [error] [client 4.35.87.33] PHP Fatal error:  Class 'Mage_Fraudalert_Helper_Data' not found in /var/www/vhosts/www.papyrusonline.com/releases/20161220195234/app/Mage.php on line 547, referer: https://papyrus.somethingdigital.com/index.php/admin/permissions_role/
